### PR TITLE
3ポジションキャリブレーション実装、0-100%マップ値に不感帯実装、LED表示を整理、レバーIDの後半をMACアドレスの下24bitに変更

### DIFF
--- a/LeverFirmware/src/Config.h
+++ b/LeverFirmware/src/Config.h
@@ -33,8 +33,10 @@
 #define UDP_DISCOVERY_PORT 4210 // UDPディスカバリー用のポート番号
 
 // センサー読み取り設定
-#define SMOOTHING_FACTOR 1      // センサー値の平滑化係数（大きいほど滑らか）
-#define CALIB_TIMEOUT 10000     // キャリブレーションタイムアウト（ミリ秒）
+#define SMOOTHING_FACTOR 5      // センサー値の平滑化係数（大きいほど滑らか）
+#define CALIB_TIMEOUT 30000     // キャリブレーションタイムアウト（ミリ秒）
 #define UPDATE_INTERVAL 50      // データ更新間隔（ミリ秒）- 20Hz
+
+#define DEAD_ZONE 1       // 不感帯の閾値
 
 #endif // CONFIG_H

--- a/LeverFirmware/src/LeverController.cpp
+++ b/LeverFirmware/src/LeverController.cpp
@@ -62,9 +62,15 @@ void LeverController::begin()
   _potReader->begin();
   _calibButton->begin();
 
+  // ネットワーク設定のリセット
+  _calibButton->update();
+  if (_calibButton->isPressed()) {
+    DEBUG_INFO("WiFi設定を削除");
+    _network->resetSettings();  //ボタンが押されていたら内蔵フラッシュメモリーのWiFi設定を削除
+  }
+
   // LEDディスプレイの初期化
   _ledDisplay.begin(_led);
-  _ledDisplay.setMode(SingleLedDisplay::POWER_ON); // 電源ON表示モード
 
   // キャリブレーションの初期化
   _calibration.begin();
@@ -76,16 +82,21 @@ void LeverController::begin()
   // APIコントローラーのコールバック設定
   _apiController.setGetLeverValueCallback([this]() { return this->getLeverValue(); });
   _apiController.setGetRawValueCallback([this]() { return this->getRawValue(); });
-  _apiController.setGetCalibrationInfoCallback([this](int& min, int& max, bool& cal) {
-    this->getCalibrationInfo(min, max, cal);
+  _apiController.setGetCalibrationInfoCallback([this](int& min, int& mid, int& max, bool& cal) {
+    this->getCalibrationInfo(min, mid, max, cal);
   });
   _apiController.setResetCalibrationCallback([this]() { this->resetCalibration(); });
   _apiController.setSetLedModeCallback([this](int mode) { this->setLedMode(mode); });
 
-
+  // 電源ON表示
+  _ledDisplay.setMode(SingleLedDisplay::POWER_ON); // 電源ON表示モード
+  while( _ledDisplay.getMode() == SingleLedDisplay::POWER_ON){
+    _ledDisplay.update();
+    delay(10);
+  }
   
   // ネットワークの初期化
-  String deviceId = "lever" + String(ESP.getChipId() & 0xFFFF, HEX);
+  String deviceId = "lever" + String(ESP.getChipId() & 0xFFFFFF, HEX);
   _network->setDeviceId(deviceId);
   _apiController.setDeviceId(deviceId);
 
@@ -95,21 +106,24 @@ void LeverController::begin()
   });
 
   // ネットワーク開始
-  _calibButton->update();
-  if (_calibButton->isPressed()) {
-    DEBUG_INFO("WiFi設定を削除");
-    _network->resetSettings();  //ボタンが押されていたら内蔵フラッシュメモリーのWiFi設定を削除
-  }
   _network->begin();
   _network->enableDiscovery(true);
 
   // ネットワーク接続待ち
   if (_network->waitForConnection(10000)) {
-    _ledDisplay.setMode(SingleLedDisplay::WIFI_CONNECTED);
     DEBUG_INFO("WiFi接続完了: " + _network->getLocalIP());
+    _ledDisplay.setMode(SingleLedDisplay::WIFI_CONNECTED);
+    // WiFi接続完了表示
+    while( _ledDisplay.getMode() == SingleLedDisplay::WIFI_CONNECTED){
+      _ledDisplay.update();
+      delay(10);
+    }
   } else {
     DEBUG_WARNING("WiFi接続失敗またはタイムアウト");
   }
+
+  // 定期的にシリアル出力するための初期化
+  _lastSerialPrintTime = millis();
 }
 
 // 定期更新（ループ内で呼び出す）
@@ -129,16 +143,21 @@ void LeverController::update()
 
   // キャリブレーションと正規化
   _calibratedValue = _calibration.mapTo0_100(_smoothedValue);
-  
+  if ( DEAD_ZONE >= ( (_calibratedValue >= _lastCalibValue) ? (_calibratedValue - _lastCalibValue) : (_lastCalibValue - _calibratedValue) ) ) {
+    _calibratedValue = _lastCalibValue; //不感帯の範囲内であれば前回値を維持;
+  }
+  _lastCalibValue = _calibratedValue;
+
   // キャリブレーション中の処理
   if (_isCalibrating) {
+    /*
     // キャリブレーション中はmin/maxを更新
     if (rawValue < _minValue) _minValue = rawValue;
     if (rawValue > _maxValue) _maxValue = rawValue;
-
+    */
     // タイムアウト確認
     if (millis() - _calibStartTime > CALIB_TIMEOUT) {
-      // タイムアウトしたら自動的にキャリブレーション終了
+      // タイムアウトしたらキャリブレーション終了
       endCalibration();
     }
   }
@@ -153,18 +172,38 @@ void LeverController::update()
     _ledDisplay.setMode(SingleLedDisplay::NORMAL_OPERATION);
     normalOperationSet = true;
   }
+
+  if ( millis()-_lastSerialPrintTime >= 10 ) {
+    //DEBUG_INFO("時刻[ms]："+String(millis()) + ", ポテンショメーターAD変換値:"+String(rawValue) + ", 出力値:"+String(_calibratedValue));
+    _lastSerialPrintTime = millis();
+  }
 }
 
 // キャリブレーション開始
 void LeverController::startCalibration()
 {
+  int rawValue = _potReader->readRawValue();
+
   if (!_isCalibrating) {
     DEBUG_INFO("キャリブレーション開始");
     _isCalibrating = true;
     _calibStartTime = millis();
-    _minValue = 1023; // 最大値から始める
-    _maxValue = 0;    // 最小値から始める
-    _ledDisplay.setMode(SingleLedDisplay::CALIBRATING);
+  }
+
+  if (rawValue < 412) {
+    _calibration.setCalibMinValue(rawValue);
+    DEBUG_INFO("キャリブレーション値 最小：" + String(_calibration.getCalibMinValue()));
+  } else if (rawValue < 612) {
+    _calibration.setCalibMidValue(rawValue);
+    DEBUG_INFO("キャリブレーション値 中間：" + String(_calibration.getCalibMidValue()));
+  } else {
+    _calibration.setCalibMaxValue(rawValue);
+    DEBUG_INFO("キャリブレーション値 最大：" + String(_calibration.getCalibMaxValue()));
+  }
+  _ledDisplay.setMode(SingleLedDisplay::CALIBRATING);
+  while( _ledDisplay.getMode() == SingleLedDisplay::CALIBRATING){
+    _ledDisplay.update();
+    delay(10);
   }
 }
 
@@ -175,8 +214,9 @@ void LeverController::endCalibration()
     DEBUG_INFO("キャリブレーション終了");
     _isCalibrating = false;
 
+    /*
     // 有効なキャリブレーション範囲かチェック
-    if (_calibration.isValidRange(_minValue, _maxValue)) {
+    if (_calibration.isValidRange(_minValue, _midValue, _maxValue)) {
       // 有効なら保存
       _calibration.saveCalibration(_minValue, _maxValue, true);
       DEBUG_INFO("キャリブレーション保存: min=" + String(_minValue) + ", max=" + String(_maxValue));
@@ -185,6 +225,13 @@ void LeverController::endCalibration()
       DEBUG_WARNING("キャリブレーション範囲が不十分です");
       _ledDisplay.setMode(SingleLedDisplay::ERROR);
       _ledDisplay.setErrorCode(1); // エラーコード1: キャリブレーション範囲不足
+    }
+    */
+    _calibration.saveCalibration();
+    _ledDisplay.setMode(SingleLedDisplay::CALIBRATED);
+    while( _ledDisplay.getMode() == SingleLedDisplay::CALIBRATED){
+      _ledDisplay.update();
+      delay(10);
     }
   }
 }
@@ -199,15 +246,16 @@ void LeverController::resetWiFiSettings()
 // キャリブレーションボタン押下時のコールバック
 void LeverController::onCalibButtonPressed()
 {
-  DEBUG_INFO("キャリブレーションボタン押下");
-  startCalibration();
+  //DEBUG_INFO("キャリブレーションボタン押下");
+  //startCalibration();
 }
 
 // キャリブレーションボタン開放時のコールバック
 void LeverController::onCalibButtonReleased()
 {
   DEBUG_INFO("キャリブレーションボタン開放");
-  endCalibration();
+  //endCalibration();
+  startCalibration();
 }
 
 // キャリブレーションリセット
@@ -239,7 +287,9 @@ String LeverController::handleApiRequest(const String& request)
 // 正規化されたレバー値を取得
 int LeverController::getLeverValue()
 {
-  return _calibratedValue;
+  // 0-1000(0.0-100.0%の10倍)を四捨五入して返す
+  // intの割り算は切り捨てになるため、+5してから10で割る
+  return ( _calibratedValue + 5 ) / 10;
 }
 
 // 生のセンサー値を取得
@@ -249,13 +299,14 @@ int LeverController::getRawValue()
 }
 
 // キャリブレーション情報を取得
-void LeverController::getCalibrationInfo(int& minVal, int& maxVal, bool& isCalibrated)
+void LeverController::getCalibrationInfo(int& minVal, int& midVal, int& maxVal, bool& isCalibrated)
 {
-  int min, max;
+  int min, mid, max;
   bool calibrated;
-  _calibration.loadCalibration(min, max, calibrated);
+  _calibration.loadCalibration(min, mid, max, calibrated);
 
   minVal = min;
+  midVal = mid;
   maxVal = max;
   isCalibrated = calibrated;
 }

--- a/LeverFirmware/src/LeverController.h
+++ b/LeverFirmware/src/LeverController.h
@@ -49,11 +49,14 @@ private:
   // 状態変数
   bool _isCalibrating;
   int _minValue;
+  int _midValue;
   int _maxValue;
   unsigned long _calibStartTime;
   int _lastRawValue;
   int _smoothedValue;
   int _calibratedValue;
+  int _lastCalibValue;
+  unsigned long _lastSerialPrintTime;
 
   // コールバック関数
   void onCalibButtonPressed();
@@ -67,7 +70,7 @@ private:
   // センサー値を取得
   int getLeverValue();
   int getRawValue();
-  void getCalibrationInfo(int& minVal, int& maxVal, bool& isCalibrated);
+  void getCalibrationInfo(int& minVal, int& midVal, int& maxVal, bool& isCalibrated);
 };
 
 #endif // LEVER_CONTROLLER_H

--- a/LeverFirmware/src/communication/ApiController.cpp
+++ b/LeverFirmware/src/communication/ApiController.cpp
@@ -119,15 +119,17 @@ String ApiController::handleApiRoot()
 
   // キャリブレーション情報の取得
   int minValue = 0;
+  int midValue = 512;
   int maxValue = 1023;
   bool isCalibrated = false;
 
   if (_getCalibrationInfoCallback) {
-    _getCalibrationInfoCallback(minValue, maxValue, isCalibrated);
+    _getCalibrationInfoCallback(minValue, midValue, maxValue, isCalibrated);
   }
 
   data["calibrated"] = isCalibrated;
   data["calib_min"] = minValue;
+  data["calib_mid"] = midValue;
   data["calib_max"] = maxValue;
 
   // ステータス情報

--- a/LeverFirmware/src/communication/ApiController.h
+++ b/LeverFirmware/src/communication/ApiController.h
@@ -17,7 +17,7 @@ using ResetCalibrationCallback = std::function<void()>;
 using SetLedModeCallback = std::function<void(int)>;
 using GetLeverValueCallback = std::function<int()>;
 using GetRawValueCallback = std::function<int()>;
-using GetCalibrationInfoCallback = std::function<void(int&, int&, bool&)>;
+using GetCalibrationInfoCallback = std::function<void(int&, int&, int&, bool&)>;
 
 class ApiController {
 public:

--- a/LeverFirmware/src/communication/WiFiManager.cpp
+++ b/LeverFirmware/src/communication/WiFiManager.cpp
@@ -29,7 +29,7 @@ RealWiFiManager::RealWiFiManager(uint16_t httpPort)
     _reconnectAttemptCount(0), // 追加: 再接続カウンター初期化
     _lastReconnectAttempt(0) // 追加: 最終再接続時間の初期化
 {
-  _deviceId = "lever" + String(ESP.getChipId() & 0xFFFF, HEX); // チップIDからデフォルトのデバイスIDを生成
+  _deviceId = "lever" + String(ESP.getChipId() & 0xFFFFFF, HEX); // チップIDからデフォルトのデバイスIDを生成
 }
 
 // デストラクタ
@@ -67,6 +67,7 @@ void RealWiFiManager::begin()
     const int MAX_INIT_ATTEMPTS = 5; // 初期接続の最大試行回数
 
     DEBUG_INFO("WiFi接続確認開始...");
+    DEBUG_INFO("MACアドレス: " + String(WiFi.macAddress()));
 
     while (!connected && attempts < MAX_INIT_ATTEMPTS) {
       attempts++;

--- a/LeverFirmware/src/core/Calibration.h
+++ b/LeverFirmware/src/core/Calibration.h
@@ -15,6 +15,7 @@
 struct CalibrationData
 {
   int minValue;      // キャリブレーション最小値
+  int midValue;      // キャリブレーション中間値
   int maxValue;      // キャリブレーション最大値
   bool isCalibrated; // キャリブレーション完了フラグ
   uint16_t checksum; // データ検証用チェックサム
@@ -30,10 +31,10 @@ public:
   void begin();
 
   // キャリブレーション値の保存
-  bool saveCalibration(int minValue, int maxValue, bool isCalibrated);
+  bool saveCalibration();
 
   // 保存されたキャリブレーション値の読み込み
-  bool loadCalibration(int &minValue, int &maxValue, bool &isCalibrated);
+  bool loadCalibration(int &minValue, int &midValue, int &maxValue, bool &isCalibrated);
 
   // 値の正規化（0-100）
   int mapTo0_100(int rawValue);
@@ -43,6 +44,24 @@ public:
 
   // キャリブレーション状態のリセット
   void resetCalibration();
+
+  // キャリブレーション最小値のセット
+  void setCalibMinValue(int minValue);
+
+  // キャリブレーション中間値のセット
+  void setCalibMidValue(int midValue);
+
+  // キャリブレーション最大値のセット
+  void setCalibMaxValue(int maxValue);
+
+  // キャリブレーション最小値の取得
+  int getCalibMinValue();
+
+  // キャリブレーション中間値の取得
+  int getCalibMidValue();
+
+  // キャリブレーション最大値の取得
+  int getCalibMaxValue();
 
 private:
   CalibrationData _calibData;


### PR DESCRIPTION
1. 3ポジションキャリブレーション実装
ボタンを押すとレバーの大まかな角度に応じて最小・中間・最大のいずれかのキャリブレーション値を記録・保持
0-100%マップ値の計算には即時反映
最初にボタンを押してから30秒後に内蔵フラッシュメモリに保存
（実装済みであった最小・最大値の間に適切な間隔があるか確認する処理は、実装できないためコメントアウト）

2. 0-100%マップ値に不感帯実装
±0.1％以下なら前回値から変更しない

3. 0-100%マップ値を保持する変数を0-1000(0.0-100.0%の10倍の実数)に変更
JSON出力は0-100％
ノイズなどによる変動を小数点以下に集約、実数部のへ影響を低減

4. LED表示を整理・パターン変更
　- 電源投入時：2秒点灯
　- 通常：2秒間隔で点滅 (0.1s点灯、1.9s消灯)
　- ボタンを押して離した時：1回点滅
　- キャリブレーション値を保存した時：2回点滅
（次の2パターンは変更していない：WiFi接続完了時、エラー時）

5. レバーIDの後半をMACアドレスの下24bitに変更
MACアドレスの下24bitは製造メーカーが製品ごとに重複しないように割り当てるため、レバーIDが一意になる
（以前はMACアドレスの下16bit）

6. 誤って無効化していたポテンショメーターの移動平均フィルタを復活
サンプル数は試作機の出力を見ながら5とした